### PR TITLE
Copy link directly 

### DIFF
--- a/template/addon/index.html
+++ b/template/addon/index.html
@@ -102,10 +102,15 @@
             });
       })
       function copyLink(event, link) {
-          let copyLinkMsg = 'Copy Share Link to Clipboard: Ctrl+C, Enter\nPaste in the Search of the Stremio App'
-          if (window.isMobile)
-              copyLinkMsg = 'Copy Share Link to Clipboard: Long Press Text, Select Copy\nPaste in the Search of the Stremio App'
-          window.prompt(copyLinkMsg, link)
+        let copyLinkMsg = 'The link was copied to your clipboard\nPress Ctrl + V in the search bar of the Stremio app and press Enter'
+        if (window.isMobile)
+            copyLinkMsg = 'The link was copied to your clipboard\nPress and hold in the search bar of the Stremio app and select Paste'
+        navigator.clipboard.writeText(link).then(function() {
+            console.log('Link copied to clipboard');
+            }, function(err) {
+            console.error('Could not copy text: ', err);
+            });
+        window.alert(copyLinkMsg)
       }
   </script>
 </body>

--- a/template/addon/index.html
+++ b/template/addon/index.html
@@ -102,15 +102,20 @@
             });
       })
       function copyLink(event, link) {
-        let copyLinkMsg = 'The link was copied to your clipboard\nPress Ctrl + V in the search bar of the Stremio app and press Enter'
-        if (window.isMobile)
-            copyLinkMsg = 'The link was copied to your clipboard\nPress and hold in the search bar of the Stremio app, select Paste and press Enter'
-        navigator.clipboard.writeText(link).then(function() {
+        console.log('link', link);
+        console.log('event', event);
+    
+        const copyLinkMsg = window.isMobile ? 'The link was copied to your clipboard.\nPress and hold in the search bar of the Stremio app, select Paste and press Enter.' : 'The link was copied to your clipboard.\nPress Ctrl + V in the search bar of the Stremio app and press Enter.';
+        const promptMsg = window.isMobile ? 'Copy the link below by pressing and holding on it and selecting Copy.\nThen press and hold in the search bar of the Stremio app, select Paste and press Enter.' : 'Copy the link below by selecting it and pressing Ctrl + C.\nThen, Press Ctrl + V in the search bar of the Stremio app and press Enter.';
+    
+        navigator.clipboard.writeText(link).then(() => {
             console.log('Link copied to clipboard');
-            }, function(err) {
+            window.alert(copyLinkMsg);
+        }).catch(err => {
             console.error('Could not copy text: ', err);
-            });
-        window.alert(copyLinkMsg)
+            console.log('Fallback to prompt');
+            window.prompt(promptMsg, link);
+        });
       }
   </script>
 </body>

--- a/template/addon/index.html
+++ b/template/addon/index.html
@@ -104,7 +104,7 @@
       function copyLink(event, link) {
         let copyLinkMsg = 'The link was copied to your clipboard\nPress Ctrl + V in the search bar of the Stremio app and press Enter'
         if (window.isMobile)
-            copyLinkMsg = 'The link was copied to your clipboard\nPress and hold in the search bar of the Stremio app and select Paste'
+            copyLinkMsg = 'The link was copied to your clipboard\nPress and hold in the search bar of the Stremio app, select Paste and press Enter'
         navigator.clipboard.writeText(link).then(function() {
             console.log('Link copied to clipboard');
             }, function(err) {

--- a/template/addon/index.html
+++ b/template/addon/index.html
@@ -116,6 +116,9 @@
             console.log('Fallback to prompt');
             window.prompt(promptMsg, link);
         });
+
+        event.preventDefault();
+        return false;
       }
   </script>
 </body>

--- a/template/home/index.html
+++ b/template/home/index.html
@@ -117,19 +117,23 @@
           loadIsotope()
       })
       function copyLink(event, link) {
-        console.log('link', link)
-        console.log('event', event)
-        let copyLinkMsg = 'The link was copied to your clipboard\nPress Ctrl + V in the search bar of the Stremio app and press Enter'
-        if (window.isMobile)
-            copyLinkMsg = 'The link was copied to your clipboard\nPress and hold in the search bar of the Stremio app, select Paste and press Enter'
-        navigator.clipboard.writeText(link).then(function() {
+        console.log('link', link);
+        console.log('event', event);
+    
+        const copyLinkMsg = window.isMobile ? 'The link was copied to your clipboard.\nPress and hold in the search bar of the Stremio app, select Paste and press Enter.' : 'The link was copied to your clipboard.\nPress Ctrl + V in the search bar of the Stremio app and press Enter.';
+        const promptMsg = window.isMobile ? 'Copy the link below by pressing and holding on it and selecting Copy.\nThen press and hold in the search bar of the Stremio app, select Paste and press Enter.' : 'Copy the link below by selecting it and pressing Ctrl + C.\nThen, Press Ctrl + V in the search bar of the Stremio app and press Enter.';
+    
+        navigator.clipboard.writeText(link).then(() => {
             console.log('Link copied to clipboard');
-            }, function(err) {
+            window.alert(copyLinkMsg);
+        }).catch(err => {
             console.error('Could not copy text: ', err);
-            });
-        window.alert(copyLinkMsg)
-        event.preventDefault()
-        return false
+            console.log('Fallback to prompt');
+            window.prompt(promptMsg, link);
+        });
+
+        event.preventDefault();
+        return false;
       }
   </script>
 </body>

--- a/template/home/index.html
+++ b/template/home/index.html
@@ -121,7 +121,7 @@
         console.log('event', event)
         let copyLinkMsg = 'The link was copied to your clipboard\nPress Ctrl + V in the search bar of the Stremio app and press Enter'
         if (window.isMobile)
-            copyLinkMsg = 'The link was copied to your clipboard\nPress and hold in the search bar of the Stremio app and select Paste'
+            copyLinkMsg = 'The link was copied to your clipboard\nPress and hold in the search bar of the Stremio app, select Paste and press Enter'
         navigator.clipboard.writeText(link).then(function() {
             console.log('Link copied to clipboard');
             }, function(err) {

--- a/template/home/index.html
+++ b/template/home/index.html
@@ -117,14 +117,19 @@
           loadIsotope()
       })
       function copyLink(event, link) {
-          console.log('link', link)
-          console.log('event', event)
-          let copyLinkMsg = 'Copy Share Link to Clipboard: Ctrl+C, Enter\nPaste in the Search of the Stremio App'
-          if (window.isMobile)
-              copyLinkMsg = 'Copy Share Link to Clipboard: Long Press Text, Select Copy\nPaste in the Search of the Stremio App'
-          window.prompt(copyLinkMsg, link)
-          event.preventDefault()
-          return false
+        console.log('link', link)
+        console.log('event', event)
+        let copyLinkMsg = 'The link was copied to your clipboard\nPress Ctrl + V in the search bar of the Stremio app and press Enter'
+        if (window.isMobile)
+            copyLinkMsg = 'The link was copied to your clipboard\nPress and hold in the search bar of the Stremio app and select Paste'
+        navigator.clipboard.writeText(link).then(function() {
+            console.log('Link copied to clipboard');
+            }, function(err) {
+            console.error('Could not copy text: ', err);
+            });
+        window.alert(copyLinkMsg)
+        event.preventDefault()
+        return false
       }
   </script>
 </body>


### PR DESCRIPTION
Instead of showing a prompt asking the user to manually copy the manifest URL, we can automatically add the URL to the user's clipboard. 

Preview:
https://deploy-preview-4--stremio-addons-list.netlify.app/
