### PR TITLE
Add install web button

### DIFF
--- a/build.js
+++ b/build.js
@@ -100,7 +100,7 @@ getCached().then(cached => {
         const lowerCaseName = addonManifest.name.toLowerCase()
         const keywordsForAddonPage = config['addon-keywords'].split('{}').join(lowerCaseName)
 
-        const installButton = !(addonManifest.behaviorHints || {}).configurationRequire ? '<a class="addon-button install-button" href="'+task.url.replace('https://','stremio://')+'">Install</a>  <a class="addon-button install-web-button" href="https://web.stremio.com/#/addons?addon='+task.url+'" target="_blank">Install (Web)</a>  <a class="addon-button copy-link-button" href="#" onClick="copyLink(\''+task.url+'\')">Copy Link</a>' : '';
+        const installButton = !(addonManifest.behaviorHints || {}).configurationRequire ? '<a class="addon-button install-button" href="'+task.url.replace('https://','stremio://')+'">Install</a>  <a class="addon-button install-web-button" href="https://web.stremio.com/#/addons?addon='+task.url+'" target="_blank">Install (Web)</a>  <a class="addon-button copy-link-button" href="#" onClick="copyLink(event, \''+task.url+'\')">Copy Link</a>' : '';
         const configButton = (addonManifest.behaviorHints || {}).configurable ? '<a class="addon-button configure-button" href="'+task.url.replace('/manifest.json','/configure')+'" target="_blank">Configure</a>' : ''
         const commentsButton = task.commentCount ? `<a href="${slug(addonManifest.name)}.html" class="addon-button last-addon-button"><ion-icon name="chatbubbles" class="gray-icon"></ion-icon> ${task.commentCount}</a>` : ''
         const language = task.language && task.language !== 'Multilingual' && task.language !== 'None' ? `<div class="addon-language">${task.language} Content</div>` : ''

--- a/build.js
+++ b/build.js
@@ -100,7 +100,7 @@ getCached().then(cached => {
         const lowerCaseName = addonManifest.name.toLowerCase()
         const keywordsForAddonPage = config['addon-keywords'].split('{}').join(lowerCaseName)
 
-        const installButton = !(addonManifest.behaviorHints || {}).configurationRequire ? '<a class="addon-button install-button" href="'+task.url.replace('https://','stremio://')+'">Install</a>  <a class="addon-button install-web-button" href="https://web.stremio.com/#/addons?addon='+task.url+'">Install (Web)</a>  <a class="addon-button copy-link-button" href="#" onClick="copyLink(\''+task.url+'\')">Copy Link</a>' : '';
+        const installButton = !(addonManifest.behaviorHints || {}).configurationRequire ? '<a class="addon-button install-button" href="'+task.url.replace('https://','stremio://')+'">Install</a>  <a class="addon-button install-web-button" href="https://web.stremio.com/#/addons?addon='+task.url+'" target="_blank">Install (Web)</a>  <a class="addon-button copy-link-button" href="#" onClick="copyLink(\''+task.url+'\')">Copy Link</a>' : '';
         const configButton = (addonManifest.behaviorHints || {}).configurable ? '<a class="addon-button configure-button" href="'+task.url.replace('/manifest.json','/configure')+'" target="_blank">Configure</a>' : ''
         const commentsButton = task.commentCount ? `<a href="${slug(addonManifest.name)}.html" class="addon-button last-addon-button"><ion-icon name="chatbubbles" class="gray-icon"></ion-icon> ${task.commentCount}</a>` : ''
         const language = task.language && task.language !== 'Multilingual' && task.language !== 'None' ? `<div class="addon-language">${task.language} Content</div>` : ''

--- a/build.js
+++ b/build.js
@@ -100,7 +100,7 @@ getCached().then(cached => {
         const lowerCaseName = addonManifest.name.toLowerCase()
         const keywordsForAddonPage = config['addon-keywords'].split('{}').join(lowerCaseName)
 
-        const installButton = !(addonManifest.behaviorHints || {}).configurationRequire ? '<a class="addon-button install-button" href="'+task.url.replace('https://','stremio://')+'">Install</a> <a class="addon-button copy-link-button" href="#" onClick="copyLink(event, \''+task.url+'\')">Copy Link</a>' : ''
+        const installButton = !(addonManifest.behaviorHints || {}).configurationRequire ? '<a class="addon-button install-button" href="'+task.url.replace('https://','stremio://')+'">Install</a>  <a class="addon-button install-web-button" href="https://web.stremio.com/#/addons?addon='+task.url+'">Install (Web)</a>  <a class="addon-button copy-link-button" href="#" onClick="copyLink(\''+task.url+'\')">Copy Link</a>' : '';
         const configButton = (addonManifest.behaviorHints || {}).configurable ? '<a class="addon-button configure-button" href="'+task.url.replace('/manifest.json','/configure')+'" target="_blank">Configure</a>' : ''
         const commentsButton = task.commentCount ? `<a href="${slug(addonManifest.name)}.html" class="addon-button last-addon-button"><ion-icon name="chatbubbles" class="gray-icon"></ion-icon> ${task.commentCount}</a>` : ''
         const language = task.language && task.language !== 'Multilingual' && task.language !== 'None' ? `<div class="addon-language">${task.language} Content</div>` : ''

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -108,6 +108,13 @@ h1 {
 .install-button:hover {
   opacity: 0.8;
 }
+.install-web-button {
+  background-color: #dc30ff;
+  color: #fff;
+}
+.install-web-button:hover {
+  opacity: 0.8;
+}
 .copy-link-button {
   background-color: #FFA030;
   color: #fff;


### PR DESCRIPTION
Adds a Install (Web) button. This button will open Stremio Web with a prompt showing to install the addon. 

This is useful for 
- iPhone / iPad users as it will allow them to install addons from the website by clicking this instead 
- Stremio Web users on desktop who don't have the app installed 

Preview: 
![image](https://github.com/user-attachments/assets/e2df6e4a-f454-4924-b1a6-1961bbbc9155)
https://deploy-preview-1--stremio-addons-list.netlify.app/
