### PR TITLE
Fix slug sanitization of non-alphanumeric characters

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,5 +1,5 @@
 const fs = require('fs')
-const slug = require('slug')
+const slug = require('./lib/slug')
 const needle = require('needle')
 const asyncQueue = require('async.queue')
 const config = require('./config')

--- a/lib/discord.js
+++ b/lib/discord.js
@@ -1,5 +1,5 @@
 const config = require('../config')
-const slug = require('slug')
+const slug = require('../lib/slug')
 const needle = require('needle')
 
 const discordGreeting = () => {

--- a/lib/slug.js
+++ b/lib/slug.js
@@ -1,0 +1,7 @@
+const _slug = require('slug')
+
+_slug.charmap['+'] = 'plus'
+
+const slug = (string, opts) => _slug(string, opts)
+
+module.exports = slug


### PR DESCRIPTION
Not all non-alphanumeric characters are added to the charmap yet but this should fix the current issue with the Easynews addon.